### PR TITLE
Add optional 16k resampling for TTS output

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ def chat():
     llm_model = req_data.get('llm_model')
     enable_memory = req_data.get('enable_memory', True)
     extra_tts_params = req_data.get('tts_params', {})
+    convert_to_16k = req_data.get('convert_to_16k', False)
     yhid = req_data.get('yhid')
 
     if not user_input:
@@ -49,7 +50,7 @@ def chat():
         return jsonify({"error": "yhid 格式错误，应为8位16进制字符串"}), 400
 
     return process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
-                                enable_memory, tts_client, extra_tts_params)
+                                enable_memory, tts_client, extra_tts_params, convert_to_16k)
 
 @app.route('/api/asr', methods=['POST'])
 def asr():
@@ -63,6 +64,7 @@ def asr():
     llm_model = request.form.get('llm_model')
     enable_memory = request.form.get('enable_memory', 'true').lower() == 'true'
     tts_params_str = request.form.get('tts_params', '{}')
+    convert_to_16k = request.form.get('convert_to_16k', 'false').lower() == 'true'
     try:
         extra_tts_params = json.loads(tts_params_str)
     except json.JSONDecodeError:
@@ -79,7 +81,7 @@ def asr():
     try:
         transcription, info = asr_processor.transcribe(audio_file, language, beam_size, task)
         return process_chat_request(transcription, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
-                                    enable_memory, tts_client, extra_tts_params)
+                                    enable_memory, tts_client, extra_tts_params, convert_to_16k)
     except Exception as e:
         return jsonify({"error": f"ASR 转写失败：{e}"}), 500
 

--- a/chat.py
+++ b/chat.py
@@ -8,7 +8,8 @@ from flask import Response, stream_with_context, jsonify
 conversation_contexts = {}
 
 def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
-                         enable_memory=True, tts_client=None, extra_tts_params={}):
+                         enable_memory=True, tts_client=None, extra_tts_params={},
+                         convert_to_16k=False):
     """
     处理聊天请求：调用 LLM 模型 API，按句分割后调用 TTS 生成语音数据，返回流式响应。
     """
@@ -49,7 +50,7 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
                     sentences = re.split(r'([。！？])', sentence_buffer)
                     for i in range(0, len(sentences) - 1, 2):
                         sentence = sentences[i] + sentences[i + 1]
-                        audio_str = tts_client.get_audio_base64(sentence, extra_tts_params) if tts_client else ""
+                        audio_str = tts_client.get_audio_base64(sentence, extra_tts_params, convert_to_16k) if tts_client else ""
                         yield json.dumps({
                             "text": sentence,
                             "audio": audio_str
@@ -64,7 +65,7 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
                             conversation_context = None
                             conversation_contexts[yhid] = None
                         if sentence_buffer:
-                            audio_str = tts_client.get_audio_base64(sentence_buffer, extra_tts_params) if tts_client else ""
+                            audio_str = tts_client.get_audio_base64(sentence_buffer, extra_tts_params, convert_to_16k) if tts_client else ""
                             yield json.dumps({
                                 "text": sentence_buffer,
                                 "audio": audio_str

--- a/tts.py
+++ b/tts.py
@@ -2,20 +2,27 @@
 import json
 import base64
 import requests
+import io
+import wave
+import audioop
 
 class TTSClient:
     def __init__(self, base_url, default_params):
         self.base_url = base_url
         self.default_params = default_params
 
-    def get_audio(self, text, extra_params=None):
+    def get_audio(self, text, extra_params=None, convert_to_16k=False):
         """
         调用 TTS 服务接口，返回音频数据的字节串，若失败返回 None。
+        当 convert_to_16k 为 True 时，将返回的音频从 32k 采样率转换为 16k。
         """
         params = self.default_params.copy()
         if extra_params:
             params.update(extra_params)
         params['text'] = text
+
+        # 如果在 extra_params 中包含转换参数，则取出并使用
+        convert_flag = params.pop('convert_to_16k', convert_to_16k)
         try:
             print("即将发送的 TTS 请求参数:")
             print(f"URL: {self.base_url}")
@@ -23,16 +30,44 @@ class TTSClient:
             response = requests.get(self.base_url, params=params, stream=True)
             response.raise_for_status()
             audio_data = b''.join(response.iter_content(chunk_size=4096))
+
+            if convert_flag:
+                audio_data = self._convert_to_16k(audio_data)
+
             return audio_data
         except requests.exceptions.RequestException as e:
             print(f"TTS 服务请求失败：{e}")
             return None
 
-    def get_audio_base64(self, text, extra_params=None):
+    def get_audio_base64(self, text, extra_params=None, convert_to_16k=False):
         """
         返回经过 Base64 编码后的音频数据字符串。
         """
-        audio_data = self.get_audio(text, extra_params)
+        audio_data = self.get_audio(text, extra_params, convert_to_16k)
         if audio_data:
             return base64.b64encode(audio_data).decode('ascii')
         return ""
+
+    def _convert_to_16k(self, audio_bytes):
+        """
+        将 WAV 音频字节流从 32k 采样率转换为 16k。
+        若输入音频采样率已为 16k，则直接返回。
+        """
+        with wave.open(io.BytesIO(audio_bytes), 'rb') as wf:
+            nchannels = wf.getnchannels()
+            sampwidth = wf.getsampwidth()
+            framerate = wf.getframerate()
+            frames = wf.readframes(wf.getnframes())
+
+        if framerate == 16000:
+            return audio_bytes
+
+        converted_frames, _ = audioop.ratecv(frames, sampwidth, nchannels, framerate, 16000, None)
+        out_buf = io.BytesIO()
+        with wave.open(out_buf, 'wb') as wf_out:
+            wf_out.setnchannels(nchannels)
+            wf_out.setsampwidth(sampwidth)
+            wf_out.setframerate(16000)
+            wf_out.writeframes(converted_frames)
+
+        return out_buf.getvalue()


### PR DESCRIPTION
## Summary
- allow API callers to request 16kHz audio by adding `convert_to_16k` parameter
- resample returned TTS audio from 32kHz to 16kHz when requested
- propagate the parameter through chat processing to the TTS client

## Testing
- `python -m py_compile app.py chat.py tts.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada566d458832f81eb2c9e70bbc0b2