### PR TITLE
Add optional 16k audio resampling

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ def chat():
     llm_model = req_data.get('llm_model')
     enable_memory = req_data.get('enable_memory', True)
     extra_tts_params = req_data.get('tts_params', {})
+    convert_to_16k = req_data.get('convert_to_16k', False)
     yhid = req_data.get('yhid')
 
     if not user_input:
@@ -49,7 +50,8 @@ def chat():
         return jsonify({"error": "yhid 格式错误，应为8位16进制字符串"}), 400
 
     return process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
-                                enable_memory, tts_client, extra_tts_params)
+                                enable_memory, tts_client, extra_tts_params,
+                                convert_to_16k)
 
 @app.route('/api/asr', methods=['POST'])
 def asr():
@@ -63,6 +65,7 @@ def asr():
     llm_model = request.form.get('llm_model')
     enable_memory = request.form.get('enable_memory', 'true').lower() == 'true'
     tts_params_str = request.form.get('tts_params', '{}')
+    convert_to_16k = request.form.get('convert_to_16k', 'false').lower() == 'true'
     try:
         extra_tts_params = json.loads(tts_params_str)
     except json.JSONDecodeError:
@@ -79,7 +82,8 @@ def asr():
     try:
         transcription, info = asr_processor.transcribe(audio_file, language, beam_size, task)
         return process_chat_request(transcription, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
-                                    enable_memory, tts_client, extra_tts_params)
+                                    enable_memory, tts_client, extra_tts_params,
+                                    convert_to_16k)
     except Exception as e:
         return jsonify({"error": f"ASR 转写失败：{e}"}), 500
 

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 import re
 import json
+import logging
 
 from config import load_config
 from asr import ASRProcessor
@@ -25,8 +26,10 @@ API_PORT = config.get("API_PORT")
 app = Flask(__name__)
 CORS(app)
 
+logger = logging.getLogger(__name__)
+
 # 初始化 ASR 模型
-print("正在加载 ASR 模型，请稍候...")
+logger.info("正在加载 ASR 模型，请稍候...")
 asr_processor = ASRProcessor(ASR_MODEL_PATH, ASR_MODEL_SIZE)
 
 # 初始化 TTS 客户端

--- a/asr.py
+++ b/asr.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import json
 import re
+import logging
 import opencc
 import torch
 import wave
@@ -14,6 +15,7 @@ t2s = opencc.OpenCC('t2s.json')
 class ASRProcessor:
     def __init__(self, model_path, model_size):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.logger = logging.getLogger(__name__)
         try:
             self.model = WhisperModel(
                 model_size_or_path=model_path,
@@ -21,9 +23,9 @@ class ASRProcessor:
                 compute_type="float16",
                 local_files_only=True
             )
-            print("ASR 模型加载完成。")
+            self.logger.info("ASR 模型加载完成。")
         except Exception as e:
-            print(f"ASR 模型加载失败：{e}")
+            self.logger.error("ASR 模型加载失败：%s", e)
             self.model = None
 
     def transcribe(self, audio_file, language=None, beam_size=5, task='transcribe'):

--- a/chat.py
+++ b/chat.py
@@ -8,7 +8,8 @@ from flask import Response, stream_with_context, jsonify
 conversation_contexts = {}
 
 def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
-                         enable_memory=True, tts_client=None, extra_tts_params={}):
+                         enable_memory=True, tts_client=None, extra_tts_params={},
+                         convert_to_16k=False):
     """
     处理聊天请求：调用 LLM 模型 API，按句分割后调用 TTS 生成语音数据，返回流式响应。
     """
@@ -49,7 +50,9 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
                     sentences = re.split(r'([。！？])', sentence_buffer)
                     for i in range(0, len(sentences) - 1, 2):
                         sentence = sentences[i] + sentences[i + 1]
-                        audio_str = tts_client.get_audio_base64(sentence, extra_tts_params) if tts_client else ""
+                        audio_str = tts_client.get_audio_base64(
+                            sentence, extra_tts_params, convert_to_16k
+                        ) if tts_client else ""
                         yield json.dumps({
                             "text": sentence,
                             "audio": audio_str
@@ -64,7 +67,9 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
                             conversation_context = None
                             conversation_contexts[yhid] = None
                         if sentence_buffer:
-                            audio_str = tts_client.get_audio_base64(sentence_buffer, extra_tts_params) if tts_client else ""
+                            audio_str = tts_client.get_audio_base64(
+                                sentence_buffer, extra_tts_params, convert_to_16k
+                            ) if tts_client else ""
                             yield json.dumps({
                                 "text": sentence_buffer,
                                 "audio": audio_str

--- a/chat.py
+++ b/chat.py
@@ -2,10 +2,12 @@
 import json
 import re
 import requests
+import logging
 from flask import Response, stream_with_context, jsonify
 
 # 全局会话上下文（可考虑使用更复杂的存储方案）
 conversation_contexts = {}
+logger = logging.getLogger(__name__)
 
 def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
                          enable_memory=True, tts_client=None, extra_tts_params={},
@@ -25,8 +27,7 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
     if enable_memory and conversation_context is not None:
         data['context'] = conversation_context
 
-    print(f"用户 {yhid} 请求数据:")
-    print(json.dumps(data, indent=4, ensure_ascii=False))
+    logger.info("用户 %s 请求数据: %s", yhid, json.dumps(data, ensure_ascii=False))
 
     try:
         response = requests.post(MODEL_API_URL, json=data, stream=True)
@@ -76,6 +77,6 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
                             }, ensure_ascii=False) + '\n'
                         break
                 except json.JSONDecodeError:
-                    print(f"无法解析的响应行: {line}")
+                    logger.warning("无法解析的响应行: %s", line)
 
     return Response(stream_with_context(generate()), mimetype='application/json; charset=utf-8')

--- a/config.py
+++ b/config.py
@@ -1,6 +1,13 @@
 # config.py
 import os
 import json
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s] %(levelname)s: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 
 CONFIG_FILE = 'config.json'
 
@@ -37,7 +44,7 @@ def create_default_config():
     """生成默认配置文件。"""
     with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
         json.dump(default_config, f, ensure_ascii=False, indent=4)
-    print("已生成默认的 config.json 文件，请根据需要修改配置。")
+    logging.info("已生成默认的 config.json 文件，请根据需要修改配置。")
 
 def load_config():
     """加载配置文件，忽略以 '__comment' 开头的键。"""
@@ -51,4 +58,4 @@ def load_config():
 if __name__ == '__main__':
     # 仅用于测试配置加载
     config = load_config()
-    print("配置加载成功：", config)
+    logging.info("配置加载成功：%s", config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ requests
 faster-whisper
 torch
 opencc
+soundfile
+resampy

--- a/tts.py
+++ b/tts.py
@@ -2,13 +2,16 @@
 import json
 import base64
 import requests
+import io
+import soundfile as sf
+import resampy
 
 class TTSClient:
     def __init__(self, base_url, default_params):
         self.base_url = base_url
         self.default_params = default_params
 
-    def get_audio(self, text, extra_params=None):
+    def get_audio(self, text, extra_params=None, convert_to_16k=False):
         """
         调用 TTS 服务接口，返回音频数据的字节串，若失败返回 None。
         """
@@ -23,16 +26,25 @@ class TTSClient:
             response = requests.get(self.base_url, params=params, stream=True)
             response.raise_for_status()
             audio_data = b''.join(response.iter_content(chunk_size=4096))
+
+            if convert_to_16k:
+                with io.BytesIO(audio_data) as input_buffer:
+                    data, sr = sf.read(input_buffer)
+                if sr != 16000:
+                    data_16k = resampy.resample(data, sr, 16000)
+                    output_buffer = io.BytesIO()
+                    sf.write(output_buffer, data_16k, 16000, format='WAV')
+                    audio_data = output_buffer.getvalue()
             return audio_data
         except requests.exceptions.RequestException as e:
             print(f"TTS 服务请求失败：{e}")
             return None
 
-    def get_audio_base64(self, text, extra_params=None):
+    def get_audio_base64(self, text, extra_params=None, convert_to_16k=False):
         """
         返回经过 Base64 编码后的音频数据字符串。
         """
-        audio_data = self.get_audio(text, extra_params)
+        audio_data = self.get_audio(text, extra_params, convert_to_16k)
         if audio_data:
             return base64.b64encode(audio_data).decode('ascii')
         return ""

--- a/tts.py
+++ b/tts.py
@@ -3,6 +3,7 @@ import json
 import base64
 import requests
 import io
+import logging
 import soundfile as sf
 import resampy
 
@@ -19,10 +20,9 @@ class TTSClient:
         if extra_params:
             params.update(extra_params)
         params['text'] = text
+        logger = logging.getLogger(__name__)
         try:
-            print("即将发送的 TTS 请求参数:")
-            print(f"URL: {self.base_url}")
-            print(f"参数: {params}")
+            logger.info("TTS 请求: url=%s, params=%s", self.base_url, params)
             response = requests.get(self.base_url, params=params, stream=True)
             response.raise_for_status()
             audio_data = b''.join(response.iter_content(chunk_size=4096))
@@ -37,10 +37,10 @@ class TTSClient:
                         sf.write(output_buffer, data_16k, 16000, format='WAV')
                         audio_data = output_buffer.getvalue()
                 except Exception as e:
-                    print(f"音频重采样失败：{e}")
+                    logger.error("音频重采样失败：%s", e)
             return audio_data
         except requests.exceptions.RequestException as e:
-            print(f"TTS 服务请求失败：{e}")
+            logger.error("TTS 服务请求失败：%s", e)
             return None
 
     def get_audio_base64(self, text, extra_params=None, convert_to_16k=False):


### PR DESCRIPTION
## Summary
- add optional 32k→16k audio resampling in TTS client using soundfile and resampy
- allow chat and ASR APIs to request 16k output via `convert_to_16k` flag
- include audio resampling dependencies

## Testing
- `python -m py_compile app.py chat.py tts.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb9c13ba4832fa012932602a63bdd