### PR TITLE
feat: add colorized structured logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from config import load_config
 from asr import ASRProcessor
 from tts import TTSClient
 from chat import process_chat_request
+from logger import log
 
 # 加载配置
 config = load_config()
@@ -26,7 +27,7 @@ app = Flask(__name__)
 CORS(app)
 
 # 初始化 ASR 模型
-print("正在加载 ASR 模型，请稍候...")
+log("APP", "INFO", "正在加载 ASR 模型，请稍候...")
 asr_processor = ASRProcessor(ASR_MODEL_PATH, ASR_MODEL_SIZE)
 
 # 初始化 TTS 客户端
@@ -104,4 +105,5 @@ def get_llm_models():
         return jsonify({"error": f"获取 LLM 模型列表失败：{e}"}), 500
 
 if __name__ == '__main__':
+    log("APP", "INFO", f"API 服务启动，端口：{API_PORT}")
     app.run(host='0.0.0.0', port=API_PORT, threaded=True, ssl_context=('cert.pem', 'key.pem'))

--- a/asr.py
+++ b/asr.py
@@ -7,6 +7,7 @@ import opencc
 import torch
 import wave
 from faster_whisper import WhisperModel
+from logger import log
 
 # 初始化 OpenCC，用于繁简体转换
 t2s = opencc.OpenCC('t2s.json')
@@ -14,6 +15,7 @@ t2s = opencc.OpenCC('t2s.json')
 class ASRProcessor:
     def __init__(self, model_path, model_size):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        log("ASR", "INFO", f"使用设备: {self.device}")
         try:
             self.model = WhisperModel(
                 model_size_or_path=model_path,
@@ -21,9 +23,9 @@ class ASRProcessor:
                 compute_type="float16",
                 local_files_only=True
             )
-            print("ASR 模型加载完成。")
+            log("ASR", "INFO", "模型加载完成。")
         except Exception as e:
-            print(f"ASR 模型加载失败：{e}")
+            log("ASR", "ERROR", f"模型加载失败：{e}")
             self.model = None
 
     def transcribe(self, audio_file, language=None, beam_size=5, task='transcribe'):
@@ -33,8 +35,10 @@ class ASRProcessor:
         with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
             audio_file.save(tmp.name)
             audio_path = tmp.name
+        log("ASR", "DEBUG", f"临时音频文件: {audio_path}")
 
         try:
+            log("ASR", "DEBUG", f"开始转写，language={language}, beam_size={beam_size}, task={task}")
             segments, info = self.model.transcribe(
                 audio_path,
                 language=language,
@@ -45,8 +49,10 @@ class ASRProcessor:
             # 如果语言为中文，则进行简体转换
             if info.language == 'zh':
                 transcription = t2s.convert(transcription)
+            log("ASR", "INFO", f"转写结果: {transcription}")
             return transcription, info
         except Exception as e:
             raise RuntimeError(f"ASR 转写失败：{e}")
         finally:
             os.remove(audio_path)
+            log("ASR", "DEBUG", f"已删除临时文件: {audio_path}")

--- a/chat.py
+++ b/chat.py
@@ -3,6 +3,7 @@ import json
 import re
 import requests
 from flask import Response, stream_with_context, jsonify
+from logger import log
 
 # 全局会话上下文（可考虑使用更复杂的存储方案）
 conversation_contexts = {}
@@ -24,8 +25,7 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
     if enable_memory and conversation_context is not None:
         data['context'] = conversation_context
 
-    print(f"用户 {yhid} 请求数据:")
-    print(json.dumps(data, indent=4, ensure_ascii=False))
+    log("CHAT", "INFO", f"用户 {yhid} 请求数据: {json.dumps(data, ensure_ascii=False)}")
 
     try:
         response = requests.post(MODEL_API_URL, json=data, stream=True)
@@ -69,8 +69,9 @@ def process_chat_request(user_input, yhid, MODEL_API_URL, DEFAULT_LLM_MODEL,
                                 "text": sentence_buffer,
                                 "audio": audio_str
                             }, ensure_ascii=False) + '\n'
+                        log("CHAT", "INFO", f"用户 {yhid} 生成文本: {generated_text}")
                         break
                 except json.JSONDecodeError:
-                    print(f"无法解析的响应行: {line}")
+                    log("CHAT", "WARNING", f"无法解析的响应行: {line}")
 
     return Response(stream_with_context(generate()), mimetype='application/json; charset=utf-8')

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 # config.py
 import os
 import json
+from logger import log
 
 CONFIG_FILE = 'config.json'
 
@@ -37,7 +38,7 @@ def create_default_config():
     """生成默认配置文件。"""
     with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
         json.dump(default_config, f, ensure_ascii=False, indent=4)
-    print("已生成默认的 config.json 文件，请根据需要修改配置。")
+    log("CONFIG", "INFO", "已生成默认的 config.json 文件，请根据需要修改配置。")
 
 def load_config():
     """加载配置文件，忽略以 '__comment' 开头的键。"""
@@ -51,4 +52,4 @@ def load_config():
 if __name__ == '__main__':
     # 仅用于测试配置加载
     config = load_config()
-    print("配置加载成功：", config)
+    log("CONFIG", "INFO", f"配置加载成功: {config}")

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,18 @@
+from colorama import init, Fore, Style
+from datetime import datetime
+
+init(autoreset=True)
+
+LEVEL_COLORS = {
+    'INFO': Fore.GREEN,
+    'WARNING': Fore.YELLOW,
+    'ERROR': Fore.RED,
+    'DEBUG': Fore.CYAN,
+}
+
+def log(module: str, level: str, message: str) -> None:
+    """打印带有颜色和统一格式的日志信息。"""
+    level = level.upper()
+    color = LEVEL_COLORS.get(level, Fore.WHITE)
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    print(f"{color}[{timestamp}] [{level}] [{module}] {message}{Style.RESET_ALL}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 faster-whisper
 torch
 opencc
+colorama

--- a/tts.py
+++ b/tts.py
@@ -2,6 +2,7 @@
 import json
 import base64
 import requests
+from logger import log
 
 class TTSClient:
     def __init__(self, base_url, default_params):
@@ -17,15 +18,16 @@ class TTSClient:
             params.update(extra_params)
         params['text'] = text
         try:
-            print("即将发送的 TTS 请求参数:")
-            print(f"URL: {self.base_url}")
-            print(f"参数: {params}")
+            log("TTS", "INFO", "即将发送 TTS 请求")
+            log("TTS", "INFO", f"URL: {self.base_url}")
+            log("TTS", "DEBUG", f"参数: {params}")
             response = requests.get(self.base_url, params=params, stream=True)
             response.raise_for_status()
             audio_data = b''.join(response.iter_content(chunk_size=4096))
+            log("TTS", "INFO", f"TTS 请求成功，返回 {len(audio_data)} 字节")
             return audio_data
         except requests.exceptions.RequestException as e:
-            print(f"TTS 服务请求失败：{e}")
+            log("TTS", "ERROR", f"TTS 服务请求失败：{e}")
             return None
 
     def get_audio_base64(self, text, extra_params=None):


### PR DESCRIPTION
## Summary
- add reusable colored logger for uniform diagnostic output
- wire logger into ASR, TTS, chat, config and app modules
- document dependency on colorama

## Testing
- `python -m py_compile app.py asr.py tts.py chat.py config.py logger.py`
- `pip install colorama`

------
https://chatgpt.com/codex/tasks/task_e_68aded6f6bbc832fa04d8bece318cec2